### PR TITLE
docs: update repository URLs in documentationupdate links in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ npm install -g pnpm
 1. **Clone the repository**
 
 ```bash
-git clone https://github.com/djyde/ccconfig.git
-cd ccconfig
+git clone https://github.com/djyde/ccmate.git
+cd ccmate
 ```
 
 2. **Install dependencies**
@@ -162,7 +162,7 @@ All contributions go through code review to ensure:
 - Proper testing and documentation
 - Security considerations
 
-Check the [GitHub Issues](https://github.com/djyde/ccconfig/issues) for specific items that need help.
+Check the [GitHub Issues](https://github.com/djyde/ccmate/issues) for specific items that need help.
 
 ## 🙏 Recognition
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A modern desktop application for managing Claude Code configuration files**
 
-[Download Latest Release](https://randynamic.org/ccmate) • [Report Issues](https://github.com/djyde/ccconfig/issues) • [Contributing Guide](CONTRIBUTING.md)
+[Download Latest Release](https://randynamic.org/ccmate) • [Report Issues](https://github.com/djyde/ccmate/issues) • [Contributing Guide](CONTRIBUTING.md)
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
@@ -75,9 +75,9 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ### Getting Help
 
-- 📖 [Documentation](https://github.com/djyde/ccconfig/wiki)
-- 🐛 [Report Issues](https://github.com/djyde/ccconfig/issues)
-- 💬 [Discussions](https://github.com/djyde/ccconfig/discussions)
+- 📖 [Documentation](https://github.com/djyde/ccmate/wiki)
+- 🐛 [Report Issues](https://github.com/djyde/ccmate/issues)
+- 💬 [Discussions](https://github.com/djyde/ccmate/discussions)
 - 📋 [Contributing Guide](CONTRIBUTING.md)
 
 ## 📄 License
@@ -92,6 +92,6 @@ See the [LICENSE](LICENSE) file for details.
 
 **Made with ❤️ by the community**
 
-[⭐ Star this repo](https://github.com/djyde/ccconfig) • [🐦 Follow updates](https://github.com/djyde/ccconfig/releases)
+[⭐ Star this repo](https://github.com/djyde/ccmate) • [🐦 Follow updates](https://github.com/djyde/ccmate/releases)
 
 </div>


### PR DESCRIPTION
## Description

Updates outdated repository links in README.md and CONTRIBUTING.md.
Replaces references to djyde/ccconfig with the correct repository path djyde/ccmate.

## Changes
- Updated Documentation, Discussion, and Release links in README.md
- Updated clone URL in CONTRIBUTING.md
- Updated Issue tracker links in both files

## Note to Maintainer

I noticed that README.md links to Wiki and Discussions pages, but these features appear to be disabled or missing in this repository (djyde/ccmate). You might want to either enable them in the repo settings or remove these links if they are not intended to be used.
