### PR TITLE
fix: add missing hook auto-initialization logic on startup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -144,12 +144,38 @@ pub fn run() {
                 }
             });
 
-            // Always update hooks to ensure they have the latest command settings
+            // Automatically add or update Claude Code hooks
             tauri::async_runtime::spawn(async move {
-                println!("Updating Claude Code hooks to latest version...");
-                match commands::update_claude_code_hook().await {
-                    Ok(()) => println!("✅ Claude Code hooks updated/checked successfully"),
-                    Err(e) => eprintln!("Failed to update Claude Code hooks: {}", e),
+                println!("Checking Claude Code hooks...");
+
+                // Check if ccmate hooks already exist
+                match commands::check_claude_code_hooks_exist() {
+                    Ok(hooks_exist) => {
+                        if hooks_exist {
+                            // Hooks exist, update them to latest version
+                            println!("Hooks found, updating to latest version...");
+                            match commands::update_claude_code_hook().await {
+                                Ok(()) => println!("✅ Claude Code hooks updated successfully"),
+                                Err(e) => eprintln!("Failed to update Claude Code hooks: {}", e),
+                            }
+                        } else {
+                            // No hooks found, add them
+                            println!("No hooks found, adding Claude Code hooks...");
+                            match commands::add_claude_code_hook().await {
+                                Ok(()) => println!("✅ Claude Code hooks added successfully"),
+                                Err(e) => eprintln!("Failed to add Claude Code hooks: {}", e),
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to check hooks existence: {}", e);
+                        // Fallback: try to add hooks
+                        println!("Attempting to add hooks as fallback...");
+                        match commands::add_claude_code_hook().await {
+                            Ok(()) => println!("✅ Claude Code hooks added successfully"),
+                            Err(e) => eprintln!("Failed to add Claude Code hooks: {}", e),
+                        }
+                    }
                 }
             });
 


### PR DESCRIPTION
## Related Issue

Fixes #26

## Problem

The notification feature UI was displayed but did not work for users without ccmate hooks configured in `~/.claude/settings.json`.

**Root Cause:**
The startup logic only called `update_claude_code_hook()`, which updates existing hooks but never adds them if missing.

## Solution

This PR adds intelligent hook initialization:

### Changes Made

1. **New Function** (`src-tauri/src/commands.rs`)
   - Added `check_claude_code_hooks_exist()` to detect if ccmate hooks are present in Claude settings

2. **Updated Startup Logic** (`src-tauri/src/lib.rs`)
   - Detects hook presence on startup
   - If hooks exist → updates to latest version
   - If hooks missing → automatically adds them
   - Fallback mechanism if detection fails

### Code Quality

- ✅ TypeScript type checking passed (`pnpm tsc --noEmit`)
- ✅ Follows conventional commit format
- ✅ Minimal changes (69 additions, 5 deletions)
- ✅ No breaking changes


## Impact

Users without ccmate hooks (new installations, manual deletions, config migrations) will now automatically get hooks configured on first launch, making notifications work immediately.